### PR TITLE
Fixing production time bug again

### DIFF
--- a/components/CompareShip.vue
+++ b/components/CompareShip.vue
@@ -22,7 +22,7 @@
                 </h4>
                 <div class="stat">
                     <h3 v-if="!stat.time">{{ (stat.raw ? stat.stat : Math.round(stat.stat)).toLocaleString() }}</h3>
-                    <h3 v-else>{{ addZeroToTime(Math.floor(stat.stat / 60 / 60)) }}:{{ addZeroToTime(Math.floor(stat.stat / 60)) }}:{{ addZeroToTime(Math.floor(stat.stat % 60)) }}</h3>
+                    <h3 v-else>{{ addZeroToTime(Math.floor(stat.stat / 60 / 60)) }}:{{ addZeroToTime(Math.floor(stat.stat / 60) % 60) }}:{{ addZeroToTime(Math.floor(stat.stat % 60)) }}</h3>
                     <img :src="stat.img" :alt="stat.name">
                 </div>
                 <div class="comparisonImgs" v-if="!['Command Points', 'Metal', 'Crystal', 'Deuterium', 'Build Time'].includes(stat.name)">

--- a/components/CompareShip.vue
+++ b/components/CompareShip.vue
@@ -71,7 +71,7 @@ function handleClose () {
 }
 
 function addZeroToTime (num: number) {
-    if (String(num).length == 1) return num + "0";
+    if (String(num).length == 1) return "0" + num;
     else return num;
 }
 

--- a/components/EditShip.vue
+++ b/components/EditShip.vue
@@ -334,7 +334,7 @@ function handleUpgrade (upgrade: SystemUpgrade) {
 }
 
 function addZeroToTime (num: number) {
-    if (String(num).length == 1) return num + "0";
+    if (String(num).length == 1) return "0" + num;
     else return num;
 }
 

--- a/utils/credits.ts
+++ b/utils/credits.ts
@@ -11,6 +11,10 @@ export const credits: Credit[] = [{
     "All FSV830 modules", "All CV3000 modules", "Most Marshal Crux modules", "All Solar Whale Modules"],
     dateAdded: "November 28, 2023"
 }, {
+    name: "WarpPrime",
+    specific: ["Most Warspite modules", "Feature additions", "Bugfixes"],
+    dateAdded: "September 19, 2024"
+}, {
     name: "Toir",
     specific: ["Ediacaran D2", "Ediacaran C1", "Module Library redesign feedback"],
     dateAdded: "April 24, 2024"


### PR DESCRIPTION
The bug here still exists. ![image](https://github.com/user-attachments/assets/97237d22-5d33-4558-8020-1d63f20eb361)

This patch fixes it and also prevents minute values from exceeding 60 on all instances where it is needed.
